### PR TITLE
Bugfix: Use sentinel_t for those range adaptors using std::end/cend on the underlying range

### DIFF
--- a/c++/itertools/itertools.hpp
+++ b/c++/itertools/itertools.hpp
@@ -67,6 +67,7 @@ namespace itertools {
   template <typename Iter, typename EndIter>
   inline typename std::iterator_traits<Iter>::difference_type distance(Iter first, EndIter last) {
     if constexpr (std::is_same_v<typename std::iterator_traits<Iter>::iterator_category, std::random_access_iterator_tag>) {
+      // Difference should be defined also for the the case that last is a sentinel
       return last - first;
     } else {
       typename std::iterator_traits<Iter>::difference_type r(0);

--- a/c++/itertools/itertools.hpp
+++ b/c++/itertools/itertools.hpp
@@ -169,14 +169,14 @@ namespace itertools {
 
     /********************* Product Iterator ********************/
 
-    template <typename sentinel_tuple_t, typename... It>
-    struct prod_iter : iterator_facade<prod_iter<sentinel_tuple_t, It...>, std::tuple<typename std::iterator_traits<It>::value_type...>> {
+    template <typename TupleSentinel, typename... It>
+    struct prod_iter : iterator_facade<prod_iter<TupleSentinel, It...>, std::tuple<typename std::iterator_traits<It>::value_type...>> {
 
       std::tuple<It...> its_begin;
-      sentinel_tuple_t its_end;
+      TupleSentinel its_end;
       std::tuple<It...> its = its_begin;
 
-      prod_iter(std::tuple<It...> its_begin, sentinel_tuple_t its_end) : its_begin(std::move(its_begin)), its_end(std::move(its_end)) {}
+      prod_iter(std::tuple<It...> its_begin, TupleSentinel its_end) : its_begin(std::move(its_begin)), its_end(std::move(its_end)) {}
 
       template <int N>
       void _increment() {

--- a/test/c++/itertools.cpp
+++ b/test/c++/itertools.cpp
@@ -142,6 +142,25 @@ TEST(Itertools, Multi) {
 
   // Chain enumerate and transform
   for (auto [i, x] : enumerate(transform(V, l))) { std::cout << i << "  [" << std::get<0>(x) << ", " << std::get<1>(x) << "]\n"; }
+
+  // Combine transform and product
+  auto add = [](auto &&p) {
+    auto [v, w] = p;
+    return v + w;
+  };
+  int total = 0;
+  for (auto sum : transform(product(V, V), add)) total += sum;
+  EXPECT_EQ(total, 252);
+
+  // slice and zip
+  for (auto [x1, x2] : slice(zip(V, V), 0, 4)) { EXPECT_EQ(x1, x2); }
+
+  // product and transform
+  // Sum up numbers from 0 to 99 in a complicated way..
+  auto times_ten = [](auto i) { return 10 * i; };
+  total          = 0;
+  for (auto [a, b] : product(range(10), transform(range(10), times_ten))) { total += a + b; }
+  EXPECT_EQ(total, 99 * 100 / 2);
 }
 
 TEST(Itertools, Range) {


### PR DESCRIPTION
Various of the range adaptors in itertools were previously not compatible with ranges that
return a different (sentinel) type for calls to `std::end` / `std::cend` as opposed to `std::begin` / `std::cbegin`.

This commit fixes this issues and makes sure the adaptors are fully composable.